### PR TITLE
fix(ci): refine PR title update logic

### DIFF
--- a/.github/instructions/c7-github-actions.instructions.md
+++ b/.github/instructions/c7-github-actions.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '*.yml'
+applyTo: '.github/workflows/*.yml'
 ---
 TITLE: Demonstrating env Context Usage in GitHub Actions YAML
 DESCRIPTION: This YAML snippet illustrates how the `env` context can be defined at the workflow, job, and step levels in a GitHub Actions workflow. It shows how environment variables are inherited and overridden, and how the `env` context can be referenced in step `run` commands, `if` conditions, and `name` properties.

--- a/.github/instructions/c7-github-actions.instructions.md
+++ b/.github/instructions/c7-github-actions.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '.github/workflows/*.yml'
+applyTo: '.github/workflows/**/*.yml'
 ---
 TITLE: Demonstrating env Context Usage in GitHub Actions YAML
 DESCRIPTION: This YAML snippet illustrates how the `env` context can be defined at the workflow, job, and step levels in a GitHub Actions workflow. It shows how environment variables are inherited and overridden, and how the `env` context can be referenced in step `run` commands, `if` conditions, and `name` properties.

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -16,7 +16,9 @@ jobs:
           script: |
             // Extract the branch name from the head ref
             const branch = context.payload.pull_request.head.ref.split('/');
-            const expectedBranchPrefix = `${branch[0]}(${branch[1]}): `;
+            
+            // If the branch doesn't follow the expected format (type/subtype), assume it's a generated branch
+            const expectedBranchPrefix = branch.length > 1 ? `${branch[0]}(${branch[1]}): ` : 'generated(bot): ';
 
             if (context.payload.pull_request.title.startsWith(expectedBranchPrefix)) {
               console.log('PR title already starts with the expected prefix. No update needed.');

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -16,6 +16,12 @@ jobs:
           script: |
             // Extract the branch name from the head ref
             const branch = context.payload.pull_request.head.ref.split('/');
+            const expectedBranchPrefix = `${branch[0]}(${branch[1]}): `;
+
+            if (context.payload.pull_request.title.startsWith(expectedBranchPrefix)) {
+              console.log('PR title already starts with the expected prefix. No update needed.');
+              return;
+            }
             
             // Get commits on the PR to find the first commit
             const commits = await github.rest.pulls.listCommits({
@@ -33,5 +39,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              title: `${branch[0]}(${branch[1]}): ${commitMessage}`,
+              title: expectedBranchPrefix + commitMessage,
             })


### PR DESCRIPTION
## Summary by Sourcery

Refine the pull-request-title GitHub Actions workflow to skip updating PR titles when they already include the expected prefix and adjust the instructions file to only target workflow YAML files

Enhancements:
- Add a title-prefix check in the PR title update step to prevent redundant updates
- Use a computed expectedBranchPrefix variable when composing the new PR title

CI:
- Refine the pull-request-title CI job logic to early return if the title already starts with the expected prefix

Documentation:
- Update the applyTo glob in GitHub Actions instructions to only include .github/workflows/*.yml