### PR TITLE
chore(vscode): update vscode recommended settings to setup test coverage

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    "recommendations": [
+        "biomejs.biome",
+        "ryanluker.vscode-coverage-gutters",
+        "bradlc.vscode-tailwindcss",
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "mehyaa.branch-cleanup",
+        "mskelton.npm-outdated",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "javascript.preferences.importModuleSpecifier": "non-relative",
+    "javascript.preferences.importModuleSpecifierEnding": "minimal",
+    "typescript.preferences.importModuleSpecifier": "non-relative",
+    "typescript.preferences.importModuleSpecifierEnding": "minimal",
+    "typescript.preferences.preferTypeOnlyAutoImports": true,
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.addMissingImports.ts": "explicit",
+    },
+    "biome.enabled": true,
+    "biome.suggestInstallingGlobally": true,
+    "editor.defaultFormatter": "biomejs.biome",
+    "notebook.defaultFormatter": "biomejs.biome",
+    "coverage-gutters.showLineCoverage": true,
+    "coverage-gutters.showGutterCoverage": true,
+    "coverage-gutters.showRulerCoverage": true,
+    "markdown-preview-enhanced.automaticallyShowPreviewOfMarkdownBeingEdited": false,
+    "npm-outdated.level": "minor",
+}

--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,7 @@
   },
   "files": {
     "include": ["./*", "/*"],
-    "ignore": [".husky", ".next", ".vscode", "node_modules"],
+    "ignore": [".husky", ".next", ".vscode", "node_modules", "coverage"],
     "ignoreUnknown": true
   },
   "linter": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,9 @@ import { NextDevtoolsProvider } from "@next-devtools/core";
 import type { Metadata } from "next";
 import { Anton, Geist } from "next/font/google";
 import "@/features/theme/globals.css";
+import { Navbar } from "@/features/layout/Navbar";
 import clsx from "clsx";
 import { ThemeProvider } from "next-themes";
-import { Navbar } from "../features/layout/Navbar";
 
 const fontHeading = Anton({
   variable: "--font-mono",

--- a/src/features/cms/getFiles.ts
+++ b/src/features/cms/getFiles.ts
@@ -1,4 +1,4 @@
-import { getFilesFromGithub } from "./getFilesFromGithub";
+import { getFilesFromGithub } from "@/features/cms/getFilesFromGithub";
 
 const CMS_TYPE = process.env.CMS_TYPE;
 

--- a/src/features/layout/Navbar.tsx
+++ b/src/features/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { toggleDarkTheme } from "../theme/dark";
+import { toggleDarkTheme } from "@/features/theme/dark";
 
 export const Navbar = () => {
   return (

--- a/src/features/toolbox/ToolButton.tsx
+++ b/src/features/toolbox/ToolButton.tsx
@@ -1,6 +1,6 @@
+import type { Tool } from "@/features/toolbox/getTools";
+import { sanitizeSvg } from "@/features/toolbox/sanitizeSvg";
 import { clsx } from "clsx";
-import type { Tool } from "./getTools";
-import { sanitizeSvg } from "./sanitizeSvg";
 
 export function ToolButton(tool: Tool) {
   const sanitizedLogo = sanitizeSvg(tool.logo);

--- a/src/features/toolbox/Toolbox.tsx
+++ b/src/features/toolbox/Toolbox.tsx
@@ -1,7 +1,6 @@
-import { clsx } from "clsx";
-import { ToolButton } from "./ToolButton";
-import { getTools } from "./getTools";
-import type { Tool } from "./getTools";
+import { ToolButton } from "@/features/toolbox/ToolButton";
+import { type Tool, getTools } from "@/features/toolbox/getTools";
+import clsx from "clsx";
 
 export async function Toolbox() {
   const tools = await getTools();

--- a/src/features/toolbox/__docs__/ToolButton.stories.tsx
+++ b/src/features/toolbox/__docs__/ToolButton.stories.tsx
@@ -1,5 +1,5 @@
+import { ToolButton } from "@/features/toolbox/ToolButton";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { ToolButton } from "../ToolButton";
 import "@/features/theme/globals.css";
 
 const meta = {

--- a/src/features/toolbox/getTools.ts
+++ b/src/features/toolbox/getTools.ts
@@ -1,5 +1,5 @@
+import { getFiles } from "@/features/cms/getFiles";
 import { z } from "zod";
-import { getFiles } from "../cms/getFiles";
 
 const toolSchema = z.object({
   title: z.string(),

--- a/src/features/toolbox/index.tsx
+++ b/src/features/toolbox/index.tsx
@@ -1,4 +1,4 @@
-import { Toolbox } from "./Toolbox";
+import { Toolbox } from "@/features/toolbox/Toolbox";
 
 export default function ToolboxPage() {
   return <Toolbox />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ const dirname =
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   test: {
+    coverage: {
+      reporter: ["html", "lcov"],
+    },
     workspace: [
       {
         extends: true,


### PR DESCRIPTION
## Summary by Sourcery

Introduce TypeScript path alias for cleaner imports and update existing import statements; enable HTML and lcov coverage reporting in Vitest; and add VS Code workspace settings and recommended extensions for test coverage support.

Enhancements:
- Adopt absolute imports using the '@' path alias and update all existing import paths accordingly

Build:
- Introduce a '@/*' baseUrl and paths alias in tsconfig for root-level imports
- Enable HTML and lcov coverage reporters in the Vitest configuration

Tests:
- Configure Vitest to generate coverage reports in HTML and lcov formats

Chores:
- Add VS Code recommended extensions and workspace settings for improved coverage visibility