### PR TITLE
docs(tasklist): move task generation prompt into scope instructions

### DIFF
--- a/.github/instructions/feature-scope.instructions.md
+++ b/.github/instructions/feature-scope.instructions.md
@@ -1,0 +1,159 @@
+````instructions
+---
+applyTo: '**/__docs__/SCOPE.md'
+---
+
+# Scope Documentation Guide
+This guide outlines the standard format and content requirements for feature scope documentation. Following this structure ensures comprehensive, consistent, and maintainable task tracking across all features in the project.
+
+## Introduction
+
+Scope documents serve as the primary implementation roadmap for features, breaking down complex specifications into manageable, actionable tasks. Each feature should have a dedicated SCOPE.md file that follows this standardized format.
+
+## Document Structure
+
+### 1. Feature Title
+
+Begin with a clear title that matches the feature name from the specification:
+
+```markdown
+# Scope for Feature: [Feature Name]
+```
+
+### 2. Epics and Tasks Section
+
+Organize implementation work into logical epics (high-level goals) and break each epic down into specific tasks.
+
+```markdown
+## Epics and Tasks
+
+### EPIC_1: [Epic Name]
+- [x] Task description (#EPIC_1_a)
+- [ ] Task description (#EPIC_1_b)
+- [ ] Task description (#EPIC_1_c)
+
+### EPIC_2: [Epic Name]
+- [ ] Task description (#EPIC_2_a)
+  - **Depends on**: #EPIC_1_a, #EPIC_1_b
+- [ ] Task description (#EPIC_2_b)
+  - **Depends on**: #EPIC_2_a
+```
+
+## Task Numbering Pattern
+
+Tasks are numbered using a combination of the Epic ID and a letter suffix:
+
+- **Epic Format**: `EPIC_<number>` (e.g., EPIC_1, EPIC_2, EPIC_3)
+- **Task Format**: `#EPIC_<number>_<letter>` (e.g., #EPIC_1_a, #EPIC_1_b, #EPIC_2_a)
+
+This pattern provides:
+- Clear epic grouping
+- Unique task identification
+- Alphabetical ordering within epics
+- Easy cross-referencing in code comments and documentation
+
+## Epic Guidelines
+
+### Epic 1: Always Documentation and Testing
+
+The first epic should always focus on documentation and testing setup:
+
+```markdown
+### EPIC_1: Initialization
+- [x] Set up initial project docs (#EPIC_1_a)
+- [ ] Create feature flag and scaffold feature structure with // TODO comments (#EPIC_1_b)
+- [ ] Write integration tests for feature (#EPIC_1_c)
+```
+
+### Subsequent Epics: Feature Implementation
+
+Organize remaining epics by logical implementation phases:
+- Data layer / API integration
+- Core business logic
+- UI components
+- Integration and deployment
+
+## Task Requirements
+
+### Task Descriptions
+
+- Use clear, actionable language
+- Start with an action verb (Create, Implement, Build, Add, etc.)
+- Be specific enough to understand the scope
+- Include brief context when helpful
+
+### Task Dependencies
+
+- Use the `**Depends on**:` format to indicate dependencies
+- Reference specific task IDs or entire epics
+- List multiple dependencies with commas
+- Dependencies should be logical and help sequence work
+
+### Task Status
+
+- Use `[x]` for completed tasks
+- Use `[ ]` for pending tasks
+- Update status as work progresses
+
+## Complete Example
+
+```markdown
+# Roadmap for Feature: Home Page
+
+## Epics and Tasks
+
+### EPIC_1: Initialization
+- [x] Set up initial project docs (#EPIC_1_a)
+- [ ] Create feature flag and scaffold feature structure with // TODO comments (#EPIC_1_b)
+- [ ] Write integration tests for feature (#EPIC_1_c)
+
+### EPIC_2: Implement data fetching and validation
+- [ ] Implement `getHomeContent` function to fetch markdown files (#EPIC_2_a)
+- [ ] Implement zod schema validation for frontmatter fields (#EPIC_2_b)
+- [ ] Add error handling for empty or malformed content (#EPIC_2_c)
+
+### EPIC_3: Build UI components for content rendering
+- [ ] Create `ContentRenderer` component to map tags to components (#EPIC_3_a)
+  - **Depends on**: #EPIC_2_b
+- [ ] Build `HeroComponent` for hero sections (#EPIC_3_b)
+  - **Depends on**: #EPIC_3_a
+- [ ] Build `CustomComponent` for generic content (#EPIC_3_c)
+  - **Depends on**: #EPIC_3_a
+
+### EPIC_4: Integrate the feature into the main application
+- [ ] Create `HomePage` component to orchestrate content rendering (#EPIC_4_a)
+  - **Depends on**: EPIC_2, EPIC_3
+- [ ] Write visual tests for `HomePage` and add screenshots/video to the docs (#EPIC_4_b)
+  - **Depends on**: #EPIC_4_a
+```
+
+## Best Practices
+
+### Epic Organization
+
+- Keep epics focused on a single major goal
+- Aim for 3-6 tasks per epic
+- Order epics by logical implementation sequence
+- Use descriptive epic names that clearly indicate the goal
+
+### Task Granularity
+
+- Break large tasks into smaller, manageable pieces
+- Each task should be completable in a single development session
+- Avoid tasks that span multiple files or components unless they're tightly coupled
+- Include testing and documentation tasks where appropriate
+
+### Dependency Management
+
+- Clearly identify blocking dependencies
+- Avoid circular dependencies
+- Consider both technical and logical dependencies
+- Update dependencies as the implementation evolves
+
+### Maintenance
+
+- Update task status regularly
+- Add new tasks as they're discovered during implementation
+- Remove or modify tasks that become obsolete
+- Keep descriptions current with the actual implementation
+````

--- a/.github/prompts/spec.prompt.md
+++ b/.github/prompts/spec.prompt.md
@@ -19,40 +19,6 @@ Once you've created the specification and README, you will ask me to review them
 
 Step 3:
 
-Create a new file `src/features/<tag_name>/__docs__/TASKS.md` for the feature based on the `src/features/<tag_name>/__docs__/SPEC.md` document. This file should outline the specific implementation tasks required to complete an MVP of the feature.
+Create a new file `src/features/<tag_name>/__docs__/SCOPE.md` for the feature based on the `src/features/<tag_name>/__docs__/SPEC.md` document. This file should outline the specific implementation tasks required to complete an MVP of the feature.
 
-Requirements of the TASKS.md file:
-- First, outline the MVP "Epics" of the feature, which are the high-level goals or milestones. Give each an EPIC_ID in the format `EPIC_<number>`, starting from 1.
-- Then, break each Epic down into smaller tasks. Each task should be numbered in order and display their dependencies.
-- The first Epic should always be about creating all the docs and integration tests for the feature. No other epic needs to mention tests or docs.
-
-Example:
-```markdown
-# Task List for Feature: Home Page
-
-## Epics and Tasks
-
-### EPIC_1: Initialization
-- [x] Set up initial project docs (#1)
-- [ ] Create feature flag and scaffold feature structure with // TODO comments (#2)
-- [ ] Write integration tests for feature (#3)
-
-### EPIC_2: Implement data fetching and validation
-- [ ] Implement `getHomeContent` function to fetch markdown files (#4)
-- [ ] Implement zod schema validation for frontmatter fields (#5)
-- [ ] Add error handling for empty or malformed content (#6)
-
-### EPIC_3: Build UI components for content rendering
-- [ ] Create `ContentRenderer` component to map tags to components (#7)
-  - **Depends on**: #5
-- [ ] Build `HeroComponent` for hero sections (#8)
-  - **Depends on**: #7
-- [ ] Build `CustomComponent` for generic content (#9)
-  - **Depends on**: #7
-
-### EPIC_4: Integrate the feature into the main application
-- [ ] Create `HomePage` component to orchestrate content rendering (#10)
-  - **Depends on**: EPIC_2, EPIC_3
-- [ ] Write visual tests for `HomePage` and add screenshots/video to the docs (#11)
-  - **Depends on**: #10
-```
+Use `.github/instructions/scope.instructions.md` as the template and guide for creating the scope document.

--- a/.github/prompts/spec.prompt.md
+++ b/.github/prompts/spec.prompt.md
@@ -21,4 +21,4 @@ Step 3:
 
 Create a new file `src/features/<tag_name>/__docs__/SCOPE.md` for the feature based on the `src/features/<tag_name>/__docs__/SPEC.md` document. This file should outline the specific implementation tasks required to complete an MVP of the feature.
 
-Use `.github/instructions/scope.instructions.md` as the template and guide for creating the scope document.
+Use `.github/instructions/feature-scope.instructions.md` as the template and guide for creating the scope document.


### PR DESCRIPTION
## Summary by Sourcery

Move task generation from ad-hoc TASKS.md to a standardized SCOPE.md process and introduce a dedicated instructions template to guide scope documentation.

Enhancements:
- Replace TASKS.md generation instructions with SCOPE.md creation in spec.prompt.md
- Add a comprehensive feature-scope.instructions.md template for standardizing feature scope documents