### PR TITLE
fix(home): fix markdown content not displaying

### DIFF
--- a/src/features/cms/getContent.ts
+++ b/src/features/cms/getContent.ts
@@ -30,7 +30,7 @@ export async function getContent<T>(
 function schemaAdapter(file: matter.GrayMatterFile<string>, schema: ZodType) {
   const fileData = {
     ...file.data,
-    content: file.content, // Raw markdown content
+    children: file.content, // Raw markdown content
   };
   // Validate frontmatter against schema
   const validation = schema.safeParse(fileData);

--- a/src/features/home/__tests__/home.regression.spec.ts
+++ b/src/features/home/__tests__/home.regression.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Home Page Regression Tests", { tag: ["@regression"] }, () => {
+  test("should maintain performance under load", async ({ page }) => {
+    await test.step("should load page within performance budget", async () => {
+      const startTime = Date.now();
+      await page.goto("/");
+      await expect(page.getByRole("main")).toBeVisible();
+      const totalTime = Date.now() - startTime;
+
+      // Performance budget: 5 seconds for complete page load
+      expect(totalTime, `Page load took ${totalTime}ms`).toBeLessThan(5000);
+    });
+
+    await test.step("should not have excessive layout shifts", async () => {
+      await page.goto("/");
+
+      // Wait for initial content to load
+      await expect(page.getByRole("main")).toBeVisible();
+
+      // Capture initial layout
+      const mainElement = page.getByRole("main");
+      const initialBounds = await mainElement.boundingBox();
+
+      // Wait for any dynamic content to settle
+      await page.waitForTimeout(1000);
+
+      const finalBounds = await mainElement.boundingBox();
+
+      expect(initialBounds).toBeTruthy();
+      expect(finalBounds).toBeTruthy();
+
+      if (initialBounds && finalBounds) {
+        // Allow for small layout adjustments but no major shifts
+        const heightDifference = Math.abs(
+          finalBounds.height - initialBounds.height,
+        );
+        expect(
+          heightDifference,
+          `Layout shift of ${heightDifference}px detected`,
+        ).toBeLessThan(100);
+      }
+    });
+  });
+});

--- a/src/features/home/__tests__/home.smoke.spec.ts
+++ b/src/features/home/__tests__/home.smoke.spec.ts
@@ -4,65 +4,13 @@ test.describe("Home Page Smoke Tests", { tag: ["@smoke"] }, () => {
   test("should load home page with hero content successfully", async ({
     page,
   }) => {
-    await test.step("should navigate to home page", async () => {
-      const startTime = Date.now();
-      await page.goto("/");
-      const loadTime = Date.now() - startTime;
-
-      // Critical path should load within 3 seconds
-      expect(loadTime, `Home page took ${loadTime}ms to load`).toBeLessThan(
-        3000,
-      );
-    });
-
     await test.step("should display main content area", async () => {
+      await page.goto("/");
       await expect(page.getByRole("main")).toBeVisible();
     });
 
     await test.step("should render hero section content", async () => {
       await expect(page.getByRole("heading").first()).toBeVisible();
-    });
-  });
-
-  test("should maintain performance under load", async ({ page }) => {
-    await test.step("should load page within performance budget", async () => {
-      const startTime = Date.now();
-      await page.goto("/");
-      await expect(page.getByRole("main")).toBeVisible();
-      const totalTime = Date.now() - startTime;
-
-      // Performance budget: 5 seconds for complete page load
-      expect(totalTime, `Page load took ${totalTime}ms`).toBeLessThan(5000);
-    });
-
-    await test.step("should not have excessive layout shifts", async () => {
-      await page.goto("/");
-
-      // Wait for initial content to load
-      await expect(page.getByRole("main")).toBeVisible();
-
-      // Capture initial layout
-      const mainElement = page.getByRole("main");
-      const initialBounds = await mainElement.boundingBox();
-
-      // Wait for any dynamic content to settle
-      await page.waitForTimeout(1000);
-
-      const finalBounds = await mainElement.boundingBox();
-
-      expect(initialBounds).toBeTruthy();
-      expect(finalBounds).toBeTruthy();
-
-      if (initialBounds && finalBounds) {
-        // Allow for small layout adjustments but no major shifts
-        const heightDifference = Math.abs(
-          finalBounds.height - initialBounds.height,
-        );
-        expect(
-          heightDifference,
-          `Layout shift of ${heightDifference}px detected`,
-        ).toBeLessThan(100);
-      }
     });
   });
 });

--- a/src/features/projects/Projects.stories.tsx
+++ b/src/features/projects/Projects.stories.tsx
@@ -7,7 +7,7 @@ const mockProjects: Project[] = [
   {
     title: "UserVoice Feedback Capture",
     subtitle: "Work Project",
-    content:
+    children:
       "A browser extension for capturing product feedback wherever you are on the web. Requires and integrates into an existing UserVoice instance.",
     date: new Date("2024-01-15"),
     githubUrl: "https://github.com/example/uservoice-feedback",
@@ -18,7 +18,7 @@ const mockProjects: Project[] = [
   {
     title: "UserVoice Validation",
     subtitle: "Work Project",
-    content:
+    children:
       "A product feedback tool that lets companies test and validate product ideas or features with targeted users before development. It gathers user feedback and votes to help teams prioritize what to build based on real demand.",
     date: new Date("2023-11-20"),
     githubUrl: "https://github.com/example/uservoice-validation",
@@ -30,7 +30,7 @@ const mockProjects: Project[] = [
   {
     title: "Portfolio Website",
     subtitle: "Personal Project",
-    content:
+    children:
       "The second version of my portfolio built with Next.js, featuring a modern design and interactive components.",
     date: new Date("2023-08-10"),
     githubUrl: "https://github.com/example/portfolio-v2",

--- a/src/features/projects/Projects.tsx
+++ b/src/features/projects/Projects.tsx
@@ -33,7 +33,7 @@ export function Projects({ projects }: ProjectsProps) {
                 {project.subtitle}
               </p>
             </header>
-            <p>{project.content}</p>
+            <p>{project.children}</p>
             <div className="flex flex-col gap-2">
               {project.githubUrl && (
                 <div className="flex">

--- a/src/features/projects/schema.ts
+++ b/src/features/projects/schema.ts
@@ -7,6 +7,6 @@ export const projectSchema = z.object({
   url: z.string().optional(),
   date: z.coerce.date(),
   images: z.array(z.string()).optional(),
-  content: z.string(),
+  children: z.string(),
 });
 export type Project = z.infer<typeof projectSchema>;


### PR DESCRIPTION
## Summary by Sourcery

Standardize the property used for markdown content from `content` to `children` across the CMS adapter, project schema, UI stories, and component; streamline Home Page smoke tests by removing performance assertions and add a regression test scaffold.

Enhancements:
- Rename `content` to `children` in the CMS `getContent` adapter, project Zod schema, Projects component, and mock story definitions

Tests:
- Remove load-time and layout-shift performance checks from Home Page smoke tests
- Add a new regression test file for the Home Page